### PR TITLE
Allow ruby version to be specified as Major.Minor or Major only in Gemfile

### DIFF
--- a/gemfile_parser.go
+++ b/gemfile_parser.go
@@ -21,15 +21,14 @@ func (p GemfileParser) ParseVersion(path string) (string, error) {
 
 	quotes := `["']`
 	versionOperators := `~>|<|>|<=|>=|=`
-	versionNumber := `\d+\.\d+\.\d+`
+	versionNumber := `\d+\.\d+(\.\d+)?`
 	expression := fmt.Sprintf(`ruby %s((%s)?\s*%s)%s`, quotes, versionOperators, versionNumber, quotes)
 	re := regexp.MustCompile(expression)
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		matches := re.FindStringSubmatch(scanner.Text())
-
-		if len(matches) == 3 {
+		if len(matches) >= 3 {
 			return matches[1], nil
 		}
 	}

--- a/gemfile_parser.go
+++ b/gemfile_parser.go
@@ -21,7 +21,7 @@ func (p GemfileParser) ParseVersion(path string) (string, error) {
 
 	quotes := `["']`
 	versionOperators := `~>|<|>|<=|>=|=`
-	versionNumber := `\d+\.\d+(\.\d+)?`
+	versionNumber := `\d+(\.\d+)?(\.\d+)?`
 	expression := fmt.Sprintf(`ruby %s((%s)?\s*%s)%s`, quotes, versionOperators, versionNumber, quotes)
 	re := regexp.MustCompile(expression)
 

--- a/gemfile_parser_test.go
+++ b/gemfile_parser_test.go
@@ -44,6 +44,8 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 		context("when given different types of versions", func() {
 			it("parses the versions correctly", func() {
 				versions := []string{
+					`"2"`,
+					`"~> 2"`,
 					`"2.6"`,
 					`"2.6.0"`,
 					`"~> 2.6"`,

--- a/gemfile_parser_test.go
+++ b/gemfile_parser_test.go
@@ -44,7 +44,9 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 		context("when given different types of versions", func() {
 			it("parses the versions correctly", func() {
 				versions := []string{
+					`"2.6"`,
 					`"2.6.0"`,
+					`"~> 2.6"`,
 					`"~> 2.6.0"`,
 					`"~> 2.7.0"`,
 					`'~> 2.7.0'`,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Will resolve #135 - allows more relaxed version requirements when specifying Ruby in the Gemfile. This PR will land when https://github.com/paketo-buildpacks/packit/pull/108 is merged, and the MRI buildpack contains the new packit changes. Without the packit changes, the postal dependency resolver will not know how to resolve `~>`.

## Use Cases
<!-- An explanation of the use cases your change enables -->

See #135 

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.
