### PR TITLE
Adds optional VersionSource to BuildPlanMetadata

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -14,9 +14,10 @@ type VersionParser interface {
 }
 
 type BuildPlanMetadata struct {
-	Version string `toml:"version"`
-	Build   bool   `toml:"build"`
-	Launch  bool   `toml:"launch"`
+	Version       string `toml:"version"`
+	VersionSource string `toml:"version-source,omitempty"`
+	Build         bool   `toml:"build"`
+	Launch        bool   `toml:"launch"`
 }
 
 func Detect(gemfileParser VersionParser) packit.DetectFunc {
@@ -27,6 +28,10 @@ func Detect(gemfileParser VersionParser) packit.DetectFunc {
 				return packit.DetectResult{}, packit.Fail.WithMessage("Gemfile is not present")
 			}
 			return packit.DetectResult{}, err
+		}
+		var versionSource string
+		if mriVersion != "" {
+			versionSource = "Gemfile"
 		}
 
 		return packit.DetectResult{
@@ -44,8 +49,9 @@ func Detect(gemfileParser VersionParser) packit.DetectFunc {
 					{
 						Name: MRIDependency,
 						Metadata: BuildPlanMetadata{
-							Version: mriVersion,
-							Build:   true,
+							Version:       mriVersion,
+							VersionSource: versionSource,
+							Build:         true,
 						},
 					},
 				},

--- a/detect_test.go
+++ b/detect_test.go
@@ -92,8 +92,9 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					{
 						Name: "mri",
 						Metadata: bundleinstall.BuildPlanMetadata{
-							Version: "2.6.x",
-							Build:   true,
+							Version:       "2.6.x",
+							VersionSource: "Gemfile",
+							Build:         true,
 						},
 					},
 				},

--- a/integration.json
+++ b/integration.json
@@ -1,5 +1,5 @@
 {
-  "build-plan": "github.com/ForestEckhardt/build-plan",
-  "bundler": "github.com/paketo-community/bundler",
-  "mri": "github.com/paketo-community/mri"
+  "build-plan": "github.com/paketo-community/build-plan",
+  "bundler": "github.com/paketo-buildpacks/bundler",
+  "mri": "github.com/paketo-buildpacks/mri"
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds the optional `VersionSource` field to the `BuildPlanMetadata` struct. 
Currently, when the `mri` version is specified via `Gemfile` the version source shows up in the MRI buildpack log output as:
```
 Candidate version sources (in priority order):
      <unknown> -> "*"
      <unknown> -> "*"

    Selected MRI version (using <unknown>): 2.7.2
```
For clarity, the version source should be `Gemfile` to make it clearer for users where versions are coming from.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
