### PR TITLE
Check ruby version 2

### DIFF
--- a/fakes/version_resolver.go
+++ b/fakes/version_resolver.go
@@ -1,0 +1,25 @@
+package fakes
+
+import "sync"
+
+type VersionResolver struct {
+	LookupCall struct {
+		sync.Mutex
+		CallCount int
+		Returns   struct {
+			Version string
+			Err     error
+		}
+		Stub func() (string, error)
+	}
+}
+
+func (f *VersionResolver) Lookup() (string, error) {
+	f.LookupCall.Lock()
+	defer f.LookupCall.Unlock()
+	f.LookupCall.CallCount++
+	if f.LookupCall.Stub != nil {
+		return f.LookupCall.Stub()
+	}
+	return f.LookupCall.Returns.Version, f.LookupCall.Returns.Err
+}

--- a/fakes/version_resolver.go
+++ b/fakes/version_resolver.go
@@ -3,6 +3,19 @@ package fakes
 import "sync"
 
 type VersionResolver struct {
+	CompareMajorMinorCall struct {
+		sync.Mutex
+		CallCount int
+		Receives  struct {
+			String_1 string
+			String_2 string
+		}
+		Returns struct {
+			Bool  bool
+			Error error
+		}
+		Stub func(string, string) (bool, error)
+	}
 	LookupCall struct {
 		sync.Mutex
 		CallCount int
@@ -14,6 +27,17 @@ type VersionResolver struct {
 	}
 }
 
+func (f *VersionResolver) CompareMajorMinor(param1 string, param2 string) (bool, error) {
+	f.CompareMajorMinorCall.Lock()
+	defer f.CompareMajorMinorCall.Unlock()
+	f.CompareMajorMinorCall.CallCount++
+	f.CompareMajorMinorCall.Receives.String_1 = param1
+	f.CompareMajorMinorCall.Receives.String_2 = param2
+	if f.CompareMajorMinorCall.Stub != nil {
+		return f.CompareMajorMinorCall.Stub(param1, param2)
+	}
+	return f.CompareMajorMinorCall.Returns.Bool, f.CompareMajorMinorCall.Returns.Error
+}
 func (f *VersionResolver) Lookup() (string, error) {
 	f.LookupCall.Lock()
 	defer f.LookupCall.Unlock()

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/semver v1.5.0
-	github.com/blang/semver v3.5.0+incompatible
 	github.com/onsi/gomega v1.10.5
 	github.com/paketo-buildpacks/occam v0.1.1
 	github.com/paketo-buildpacks/packit v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.14
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/Masterminds/semver v1.5.0
+	github.com/blang/semver v3.5.0+incompatible
 	github.com/onsi/gomega v1.10.5
 	github.com/paketo-buildpacks/occam v0.1.1
 	github.com/paketo-buildpacks/packit v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ github.com/aws/aws-sdk-go v1.31.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/init_test.go
+++ b/init_test.go
@@ -14,5 +14,6 @@ func TestUnitBundleInstall(t *testing.T) {
 	suite("Detect", testDetect)
 	suite("GemfileParser", testGemfileParser)
 	suite("LogEmitter", testLogEmitter)
+	suite("RubyVersionResolver", testRubyVersionResolver)
 	suite.Run(t)
 }

--- a/ruby_version_resolver.go
+++ b/ruby_version_resolver.go
@@ -1,0 +1,40 @@
+package bundleinstall
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+
+	"github.com/paketo-buildpacks/packit/pexec"
+)
+
+type RubyVersionResolver struct {
+	executable Executable
+}
+
+func NewRubyVersionResolver(executable Executable) RubyVersionResolver {
+	return RubyVersionResolver{
+		executable: executable,
+	}
+}
+
+func (r RubyVersionResolver) Lookup() (string, error) {
+	buffer := bytes.NewBuffer(nil)
+	err := r.executable.Execute(pexec.Execution{
+		Args:   []string{"--version"},
+		Stdout: buffer,
+		Stderr: buffer,
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to obtain ruby version: %w: %s", err, buffer.String())
+	}
+
+	versions := regexp.MustCompile(`ruby (\d+\.\d+\.\d+)`).FindStringSubmatch(buffer.String())
+	if versions == nil {
+		return "", fmt.Errorf("no string matching 'ruby (\\d+\\.\\d+\\.\\d+)' found")
+	}
+
+	// return just the numeric version part of the `ruby --version` output
+	return versions[1], nil
+}

--- a/ruby_version_resolver.go
+++ b/ruby_version_resolver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/Masterminds/semver"
 	"github.com/paketo-buildpacks/packit/pexec"
 )
 
@@ -37,4 +38,23 @@ func (r RubyVersionResolver) Lookup() (string, error) {
 
 	// return just the numeric version part of the `ruby --version` output
 	return versions[1], nil
+}
+
+func (r RubyVersionResolver) CompareMajorMinor(cachedVersion, newVersion string) (bool, error) {
+	cachedSemverVersion, err := semver.NewVersion(cachedVersion)
+	if err != nil {
+		return false, err
+	}
+
+	majorMinorConstraint, err := semver.NewConstraint(fmt.Sprintf("%d.%d.*", cachedSemverVersion.Major(), cachedSemverVersion.Minor()))
+	if err != nil {
+		return false, err
+	}
+
+	newSemverVersion, err := semver.NewVersion(newVersion)
+	if err != nil {
+		return false, err
+	}
+
+	return majorMinorConstraint.Check(newSemverVersion), nil
 }

--- a/ruby_version_resolver_test.go
+++ b/ruby_version_resolver_test.go
@@ -1,0 +1,77 @@
+package bundleinstall_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	bundleinstall "github.com/paketo-buildpacks/bundle-install"
+	"github.com/paketo-buildpacks/bundle-install/fakes"
+	"github.com/paketo-buildpacks/packit/pexec"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testRubyVersionResolver(t *testing.T, context spec.G, it spec.S) {
+	var Expect = NewWithT(t).Expect
+
+	context("Lookup", func() {
+		var (
+			executable *fakes.Executable
+
+			rubyVersionResolver bundleinstall.RubyVersionResolver
+		)
+
+		it.Before(func() {
+			executable = &fakes.Executable{}
+			executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+				fmt.Fprintf(execution.Stdout, "ruby 2.7.7p57 (2018-03-29 revision 63029) [x86_64-linux-gnu]")
+				return nil
+			}
+
+			rubyVersionResolver = bundleinstall.NewRubyVersionResolver(executable)
+		})
+
+		it("returns the ruby version", func() {
+			version, err := rubyVersionResolver.Lookup()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(version).To(Equal("2.7.7"))
+
+			Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"--version"}))
+		})
+
+		context("failure cases", func() {
+			context("fails to execute `ruby --version`", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+						fmt.Fprintf(execution.Stderr, "failed to execute")
+						return errors.New("exit status 1")
+					}
+				})
+
+				it("returns an error", func() {
+					_, err := rubyVersionResolver.Lookup()
+					Expect(err).To(MatchError(ContainSubstring("failed to obtain ruby version")))
+					Expect(err).To(MatchError(ContainSubstring("exit status 1")))
+					Expect(err).To(MatchError(ContainSubstring("failed to execute")))
+				})
+			})
+
+			context("no ruby match is found", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+						fmt.Fprintf(execution.Stdout, "")
+						return nil
+					}
+				})
+
+				it("returns an error", func() {
+					_, err := rubyVersionResolver.Lookup()
+					Expect(err).To(MatchError(ContainSubstring("no string matching 'ruby (\\d+\\.\\d+\\.\\d+)' found")))
+				})
+			})
+		})
+	})
+}

--- a/run/main.go
+++ b/run/main.go
@@ -27,6 +27,9 @@ func main() {
 			logEmitter,
 			chronos.DefaultClock,
 			draft.NewPlanner(),
+			bundleinstall.NewRubyVersionResolver(
+				pexec.NewExecutable("ruby"),
+			),
 		),
 	)
 }


### PR DESCRIPTION
Signed-off-by: Forest Eckhardt <feckhardt@pivotal.io>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves #112. 

Performs a check on the Ruby version during each build by running `ruby --version` and checking if it differs from the previous build, if there was one. This should cover the case in which we rebuild an app with a different Ruby version (i.e. with `$BP_MRI_VERSION` set), but the `Gemfile` and `Gemfile.lock` stay the same. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

This ensure that the cached `bundle-install` layer will NOT be reused if the Ruby version changes between builds.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.
