### PR TITLE
Sort config asserts alphabetically

### DIFF
--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -126,20 +126,20 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 			logs, err = docker.Container.Logs.Execute(container.ID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(logs).To(ContainLines(
-				"retry",
-				"Set for the current user (/layers/paketo-buildpacks_bundle-install/launch-gems/config): 5",
-				"",
 				"clean",
-				`Set for the current user (/layers/paketo-buildpacks_bundle-install/launch-gems/config): "true"`,
+				"Set for the current user (/layers/paketo-buildpacks_bundle-install/launch-gems/config): true",
 				"",
 				"path",
 				`Set for the current user (/layers/paketo-buildpacks_bundle-install/launch-gems/config): "/layers/paketo-buildpacks_bundle-install/launch-gems"`,
 				"",
-				"without",
-				"Set for the current user (/layers/paketo-buildpacks_bundle-install/launch-gems/config): [:development, :test]",
+				"retry",
+				"Set for the current user (/layers/paketo-buildpacks_bundle-install/launch-gems/config): 5",
 				"",
 				"user_config",
 				`Set via BUNDLE_USER_CONFIG: "/layers/paketo-buildpacks_bundle-install/launch-gems/config"`,
+				"",
+				"without",
+				"Set for the current user (/layers/paketo-buildpacks_bundle-install/launch-gems/config): [:development, :test]",
 			))
 
 			Expect(logs).To(ContainLines(


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
In recent versions of `bundler`, the config order is sorted alphabetically. The assertion we make in our integration tests should follow this ordering.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
