### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/bundle-install"
   id = "paketo-buildpacks/bundle-install"
   keywords = ["ruby", "bundler"]
-  name = "Paketo Bundle Install Buildpack"
+  name = "Paketo Buildpack for Bundle Install"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -138,7 +138,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 			))
 
 			Expect(logs).To(ContainLines(
-				"Paketo Bundle List Buildpack",
+				"Paketo Buildpack for Bundle List",
 				"  Gems included by the bundle:",
 				MatchRegexp(`    \* coderay`),
 				MatchRegexp(`    \* diff-lcs`),
@@ -265,7 +265,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 				))
 
 				Expect(logs).To(ContainLines(
-					"Paketo Bundle List Buildpack",
+					"Paketo Buildpack for Bundle List",
 					"  Gems included by the bundle:",
 					MatchRegexp(`    \* bundler`),
 					MatchRegexp(`    \* coderay`),


### PR DESCRIPTION
Renames 'Paketo Bundle Install Buildpack' to 'Paketo Buildpack for Bundle Install'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
