### PR TITLE
Removes gem extension build files after install

### DIFF
--- a/build.go
+++ b/build.go
@@ -20,7 +20,7 @@ import (
 // build process.
 type InstallProcess interface {
 	ShouldRun(metadata map[string]interface{}, workingDir string) (should bool, checksum string, rubyVersion string, err error)
-	Execute(workingDir, layerPath string, config map[string]string) error
+	Execute(workingDir, layerPath string, config map[string]string, keepBuildFiles bool) error
 }
 
 // EntryResolver defines the interface for determining what phases of the
@@ -75,6 +75,7 @@ func Build(
 	sbomGenerator SBOMGenerator,
 	logger scribe.Emitter,
 	clock chronos.Clock,
+	environment Environment,
 ) packit.BuildFunc {
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
@@ -122,7 +123,7 @@ func Build(
 					return installProcess.Execute(context.WorkingDir, layer.Path, map[string]string{
 						"path":  layer.Path,
 						"clean": "true",
-					})
+					}, environment.KeepGemExtensionBuildFiles)
 				})
 				if err != nil {
 					return packit.BuildResult{}, err
@@ -214,7 +215,7 @@ func Build(
 						"path":    layer.Path,
 						"without": "development:test",
 						"clean":   "true",
-					})
+					}, environment.KeepGemExtensionBuildFiles)
 				})
 				if err != nil {
 					return packit.BuildResult{}, err

--- a/environment.go
+++ b/environment.go
@@ -1,0 +1,26 @@
+package bundleinstall
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Environment struct {
+	KeepGemExtensionBuildFiles bool
+}
+
+func ParseEnvironment(environ []string) (Environment, error) {
+	var environment Environment
+	for _, variable := range environ {
+		if value, found := strings.CutPrefix(variable, "BP_KEEP_GEM_EXTENSION_BUILD_FILES="); found {
+			var err error
+			environment.KeepGemExtensionBuildFiles, err = strconv.ParseBool(value)
+			if err != nil {
+				return Environment{}, fmt.Errorf("failed to parse BP_KEEP_GEM_EXTENSION_BUILD_FILES: %w", err)
+			}
+		}
+	}
+
+	return environment, nil
+}

--- a/environment_test.go
+++ b/environment_test.go
@@ -1,0 +1,48 @@
+package bundleinstall_test
+
+import (
+	"testing"
+
+	bundleinstall "github.com/paketo-buildpacks/bundle-install"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testEnvironment(t *testing.T, context spec.G, it spec.S) {
+	var Expect = NewWithT(t).Expect
+
+	context("ParseEnvironment", func() {
+		it("parse the environment variables", func() {
+			environment, err := bundleinstall.ParseEnvironment([]string{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(environment).To(Equal(bundleinstall.Environment{
+				KeepGemExtensionBuildFiles: false,
+			}))
+		})
+
+		context("when BP_KEEP_GEM_EXTENSION_BUILD_FILES is set", func() {
+			it("parse the environment variables", func() {
+				environment, err := bundleinstall.ParseEnvironment([]string{
+					"BP_KEEP_GEM_EXTENSION_BUILD_FILES=true",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(environment).To(Equal(bundleinstall.Environment{
+					KeepGemExtensionBuildFiles: true,
+				}))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when the BP_KEEP_GEM_EXTENSION_BUILD_FILES env var cannot be parsed", func() {
+				it("returns an error", func() {
+					_, err := bundleinstall.ParseEnvironment([]string{
+						"BP_KEEP_GEM_EXTENSION_BUILD_FILES=banana",
+					})
+					Expect(err).To(MatchError(ContainSubstring("failed to parse BP_KEEP_GEM_EXTENSION_BUILD_FILES:")))
+					Expect(err).To(MatchError(ContainSubstring(`parsing "banana": invalid syntax`)))
+				})
+			})
+		})
+	})
+}

--- a/fakes/entry_resolver.go
+++ b/fakes/entry_resolver.go
@@ -3,7 +3,7 @@ package fakes
 import (
 	"sync"
 
-	packit "github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2"
 )
 
 type EntryResolver struct {

--- a/fakes/install_process.go
+++ b/fakes/install_process.go
@@ -7,14 +7,15 @@ type InstallProcess struct {
 		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
-			WorkingDir string
-			LayerPath  string
-			Config     map[string]string
+			WorkingDir     string
+			LayerPath      string
+			Config         map[string]string
+			KeepBuildFiles bool
 		}
 		Returns struct {
 			Error error
 		}
-		Stub func(string, string, map[string]string) error
+		Stub func(string, string, map[string]string, bool) error
 	}
 	ShouldRunCall struct {
 		mutex     sync.Mutex
@@ -35,15 +36,16 @@ type InstallProcess struct {
 	}
 }
 
-func (f *InstallProcess) Execute(param1 string, param2 string, param3 map[string]string) error {
+func (f *InstallProcess) Execute(param1 string, param2 string, param3 map[string]string, param4 bool) error {
 	f.ExecuteCall.mutex.Lock()
 	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.WorkingDir = param1
 	f.ExecuteCall.Receives.LayerPath = param2
 	f.ExecuteCall.Receives.Config = param3
+	f.ExecuteCall.Receives.KeepBuildFiles = param4
 	if f.ExecuteCall.Stub != nil {
-		return f.ExecuteCall.Stub(param1, param2, param3)
+		return f.ExecuteCall.Stub(param1, param2, param3, param4)
 	}
 	return f.ExecuteCall.Returns.Error
 }

--- a/gemfile_parser_test.go
+++ b/gemfile_parser_test.go
@@ -3,7 +3,6 @@ package bundleinstall_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -27,7 +26,7 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		file, err := ioutil.TempFile("", "Gemfile")
+		file, err := os.CreateTemp("", "Gemfile")
 		Expect(err).NotTo(HaveOccurred())
 		defer file.Close()
 
@@ -68,7 +67,7 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 				for _, v := range versions {
 					expectedVersion := strings.Trim(v, `"'`)
 
-					Expect(ioutil.WriteFile(path, []byte(fmt.Sprintf(GEMFILE_TEMPLATE, v)), 0644)).To(Succeed())
+					Expect(os.WriteFile(path, []byte(fmt.Sprintf(GEMFILE_TEMPLATE, v)), 0644)).To(Succeed())
 
 					version, err := parser.ParseVersion(path)
 					Expect(err).NotTo(HaveOccurred())

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/paketo-buildpacks/bundle-install
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/docker/cli v23.0.2+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
-	github.com/docker/docker v23.0.2+incompatible // indirect
+	github.com/docker/docker v23.0.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1085,8 +1085,8 @@ github.com/docker/docker v20.10.12+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05
 github.com/docker/docker v20.10.17+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.20+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v23.0.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v23.0.2+incompatible h1:q81C2qQ/EhPm8COZMUGOQYh4qLv4Xu6CXELJ3WK/mlU=
-github.com/docker/docker v23.0.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v23.0.3+incompatible h1:9GhVsShNWz1hO//9BNg/dpMnZW25KydO4wtVxWAIbho=
+github.com/docker/docker v23.0.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=

--- a/init_test.go
+++ b/init_test.go
@@ -12,6 +12,7 @@ func TestUnitBundleInstall(t *testing.T) {
 	suite("Build", testBuild)
 	suite("BundleInstallProcess", testBundleInstallProcess)
 	suite("Detect", testDetect)
+	suite("Environment", testEnvironment)
 	suite("GemfileParser", testGemfileParser)
 	suite("RubyVersionResolver", testRubyVersionResolver)
 	suite.Run(t)

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -116,10 +116,12 @@ func TestIntegration(t *testing.T) {
 	// All other tests will run against the Bionic base stack
 	if builder.BuilderName == "paketobuildpacks/builder:buildpackless-full" {
 		suite("StackUpgrade", testStackUpgrade)
-	} else {
-		suite("LayerReuse", testLayerReuse)
-		suite("OfflineApp", testOffline)
-		suite("SimpleApp", testSimpleApp)
 	}
+
+	suite("LayerReuse", testLayerReuse)
+	suite("OfflineApp", testOffline)
+	suite("ReproducibleBuilds", testReproducibleBuilds)
+	suite("SimpleApp", testSimpleApp)
+
 	suite.Run(t)
 }

--- a/integration/reproducible_builds_test.go
+++ b/integration/reproducible_builds_test.go
@@ -1,0 +1,101 @@
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testReproducibleBuilds(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	var (
+		image occam.Image
+
+		name   string
+		source string
+	)
+
+	it.Before(func() {
+		var err error
+		name, err = occam.RandomName()
+		Expect(err).NotTo(HaveOccurred())
+
+		source, err = occam.Source(filepath.Join("testdata", "reproducible_builds"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+		Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+		Expect(os.RemoveAll(source)).To(Succeed())
+	})
+
+	it("creates a reproducible image", func() {
+		build := pack.Build.
+			WithBuildpacks(
+				settings.Buildpacks.MRI.Online,
+				settings.Buildpacks.Bundler.Online,
+				settings.Buildpacks.BundleInstall.Online,
+				settings.Buildpacks.BundleList.Online,
+			).
+			WithPullPolicy("never")
+
+		var err error
+		image, _, err = build.Execute(name, source)
+		Expect(err).NotTo(HaveOccurred())
+
+		firstID := image.ID
+
+		Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+		Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+
+		image, _, err = build.Execute(name, source)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(firstID).To(Equal(image.ID))
+	})
+
+	context("when given the BP_KEEP_GEM_EXTENSION_BUILD_FILES env var", func() {
+		it("does not create a reproducible build", func() {
+			build := pack.Build.
+				WithBuildpacks(
+					settings.Buildpacks.MRI.Online,
+					settings.Buildpacks.Bundler.Online,
+					settings.Buildpacks.BundleInstall.Online,
+					settings.Buildpacks.BundleList.Online,
+				).
+				WithEnv(map[string]string{"BP_KEEP_GEM_EXTENSION_BUILD_FILES": "true"}).
+				WithPullPolicy("never")
+
+			var err error
+			image, _, err = build.Execute(name, source)
+			Expect(err).NotTo(HaveOccurred())
+
+			firstID := image.ID
+
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+
+			image, _, err = build.Execute(name, source)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(firstID).NotTo(Equal(image.ID))
+		})
+	})
+}

--- a/integration/testdata/reproducible_builds/Gemfile
+++ b/integration/testdata/reproducible_builds/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+ruby '~> 3.1'
+
+gem 'unicorn'
+gem 'sinatra'

--- a/integration/testdata/reproducible_builds/README.md
+++ b/integration/testdata/reproducible_builds/README.md
@@ -1,0 +1,1 @@
+unicorn - sinatra web app

--- a/integration/testdata/reproducible_builds/app.rb
+++ b/integration/testdata/reproducible_builds/app.rb
@@ -1,0 +1,5 @@
+require 'sinatra'
+
+get '/' do
+  'Hello world!'
+end

--- a/integration/testdata/reproducible_builds/config.ru
+++ b/integration/testdata/reproducible_builds/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/integration/testdata/reproducible_builds/config/unicorn.rb
+++ b/integration/testdata/reproducible_builds/config/unicorn.rb
@@ -1,0 +1,6 @@
+app_dir = File.expand_path("../..", __FILE__)
+working_directory app_dir
+
+# Set unicorn options
+worker_processes 2
+timeout 30

--- a/run/main.go
+++ b/run/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"log"
 	"os"
 
 	bundleinstall "github.com/paketo-buildpacks/bundle-install"
@@ -22,6 +24,11 @@ func (f Generator) Generate(dir string) (sbom.SBOM, error) {
 func main() {
 	logEmitter := scribe.NewEmitter(os.Stdout).WithLevel(os.Getenv("BP_LOG_LEVEL"))
 
+	environment, err := bundleinstall.ParseEnvironment(os.Environ())
+	if err != nil {
+		log.Fatal(fmt.Errorf("failed to parse environment configuration: %w", err))
+	}
+
 	packit.Run(
 		bundleinstall.Detect(
 			bundleinstall.NewGemfileParser(),
@@ -39,6 +46,7 @@ func main() {
 			Generator{},
 			logEmitter,
 			chronos.DefaultClock,
+			environment,
 		),
 	)
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The build process will now do some cleanup of the gems it installs by removing any extra `Makefile`, `mkmf.log`, or `gem_make.out` files remaining after the install completes. Doing this will result in a layer that is reproducible since these files may contain things like random values or timestamps that differ on every build.

This was based on work done in NixOS `nixpkgs` to enable reproducibility there: https://github.com/NixOS/nixpkgs/pull/101655.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Helps to resolve https://github.com/paketo-buildpacks/ruby/issues/811

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
