### PR TITLE
buildpack.toml: remove stacks restriction

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -17,10 +17,7 @@ api = "0.7"
   pre-package = "./scripts/build.sh --target linux/amd64 --target linux/arm64"
 
 [[stacks]]
-  id = "io.buildpacks.stacks.jammy"
-
-[[stacks]]
-  id = "io.buildpacks.stacks.noble"
+  id = "*"
 
 [[targets]]
   os = "linux"


### PR DESCRIPTION
as this buildpack has nothing stack-specific
This is for reusing the buildpack in alternative builders.

## Summary
buildpack.toml: remove stacks restriction

## Use Cases
use this buildpack with other BP stacks

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
